### PR TITLE
Add a contributing file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+# Contributing to activerecord-connection_pool_instrumenter
+
+We currently do not accept any contributions from external sources.
+
+The code is still open source and if you wish to add any changes, feel free to fork it and add changes to your fork.
+
+Issues for any security-related bugs found are still welcome, but we offer no guarantees on whether or when they will be acted upon.
+
+For any exceptional cases, please contact us at open-source@glia.com.

--- a/activerecord-connection_pool_instrumenter.gemspec
+++ b/activerecord-connection_pool_instrumenter.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |spec|
   spec.name     = 'activerecord-connection_pool_instrumenter'
   spec.version  = ActiveRecord::ConnectionPoolInstrumenter::VERSION
   spec.authors  = ['Glia TechMovers']
-  spec.email    = ['techmovers@glia.com']
+  spec.email    = ['open-source@glia.com']
   spec.summary  = 'Metrics about the activerecord connection pool usage'
   spec.homepage = 'https://github.com/salemove/activerecord-connection_pool_instrumenter'
 


### PR DESCRIPTION
Our open source policy dictates that every public repository should have a contributing file. Add the default one here.

Also remove an email that we don't want used by the general public.

SEC-2232